### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "ruby main.rb"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ The codes are four colours long with the colours being chosen from six possible 
 ## Reflection
 This project was created to proactice using OOP principles. The main challenges were implementing Donald Knuth's algorithm 
 and creating an algorithm to generate the correct hints after each guess.
+
+[![Run on Repl.it](https://repl.it/badge/github/RichardDenton/mastermind)](https://repl.it/github/RichardDenton/mastermind)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).